### PR TITLE
Travis CI and phpunit updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: php
 php:
-  - 7.0
-  - 7.1
-  - nightly
+  - 7.2
+  - 7.3
 install:
   - composer self-update
   - composer install --no-interaction --dev

--- a/composer.json
+++ b/composer.json
@@ -28,10 +28,9 @@
     "phramework/util": "^0.0.0@RC"
   },
   "require-dev": {
-    "phpunit/phpunit": "6.*",
+    "phpunit/phpunit": "7.*",
     "squizlabs/php_codesniffer": "*",
-    "apigen/apigen": "^4.1",
-    "satooshi/php-coveralls": "dev-master",
+    "php-coveralls/php-coveralls": "^2.1",
     "codacy/coverage": "^1.0"
   },
   "minimum-stability": "dev",

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "phramework/util": "^0.0.0@RC"
   },
   "require-dev": {
-    "phpunit/phpunit": "7.*",
+    "phpunit/phpunit": "^7.5.17",
     "squizlabs/php_codesniffer": "*",
     "php-coveralls/php-coveralls": "^2.1",
     "codacy/coverage": "^1.0"

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -7,9 +7,7 @@
     convertErrorsToExceptions="true"
     convertNoticesToExceptions="true"
     convertWarningsToExceptions="true"
-    stopOnFailure="false"
-    logIncompleteSkipped="false"
-    debug="true">
+    stopOnFailure="false">
 
     <testsuite name="PHPUnit phramework/API">
         <directory suffix="Test.php">./tests/src/</directory>
@@ -19,7 +17,7 @@
     <logging>
         <log type="tap" target="build/report.tap"/>
         <log type="junit" target="build/report.junit.xml"/>
-        <log type="coverage-html" target="build/coverage" charset="UTF-8" yui="true" highlight="true"/>
+        <log type="coverage-html" target="build/coverage" />
         <log type="coverage-text" target="build/coverage.txt"/>
         <log type="coverage-clover" target="build/logs/clover.xml"/>
     </logging>

--- a/src/NumberValidatorFiller.php
+++ b/src/NumberValidatorFiller.php
@@ -33,7 +33,7 @@ class NumberValidatorFiller implements IValidatorFiller
         }
 
         $number = $faker->randomFloat(
-            null,
+            8,
             $minimum,
             $maximum
         );


### PR DESCRIPTION
- Update phpunit to latest version and remove unmaintained apigen
- Update travis ci manifest for php 7.2, 7.3, and 7.4